### PR TITLE
Fix open PR review security findings

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -7,6 +7,7 @@ A secure Express.js backend API server that provides Grok image generation capab
 - 🔐 **Secure API Key Management** - All xAI API keys stay on server side
 - 🚀 **Grok-2-image-1212 Integration** - Latest xAI image generation model
 - 🛡️ **Request Validation** - Joi-based validation for all inputs
+- 🧿 **CSRF Protection** - Signed CSRF tokens required for state-changing API requests
 - 📊 **Rate Limiting** - Configurable rate limits to prevent abuse
 - 📝 **Structured Logging** - Winston-based JSON logging
 - 🔄 **Retry Logic** - Automatic retries with exponential backoff
@@ -21,9 +22,21 @@ GET /health
 ```
 Returns server health status and service availability.
 
+### CSRF Token
+```
+GET /api/csrf-token
+```
+Returns a signed token for state-changing API requests. Send the token in the `x-csrf-token` header when calling `POST /api/generateImage`.
+
 ### Image Generation
 ```
 POST /api/generateImage
+```
+
+**Required Headers:**
+```http
+Content-Type: application/json
+x-csrf-token: <token from GET /api/csrf-token>
 ```
 
 **Request Body:**
@@ -89,6 +102,9 @@ RATE_LIMIT_MAX_REQUESTS=100
 LOG_LEVEL=info
 LOG_FORMAT=json
 
+# CSRF
+CSRF_SECRET=use-a-long-random-secret-in-production
+
 # CORS
 CORS_ORIGIN=*
 ```
@@ -122,8 +138,11 @@ curl http://localhost:3001/health
 
 Test image generation:
 ```bash
+CSRF_TOKEN=$(curl -s http://localhost:3001/api/csrf-token | node -e "process.stdin.on('data', d => console.log(JSON.parse(d).csrfToken))")
+
 curl -X POST http://localhost:3001/api/generateImage \
   -H "Content-Type: application/json" \
+  -H "x-csrf-token: ${CSRF_TOKEN}" \
   -d '{"prompt": "A cosmic horror scene with tentacles in space"}'
 ```
 
@@ -187,6 +206,10 @@ In production, logs are written to:
 - `logs/error.log` - Error level logs only
 - `logs/combined.log` - All logs
 
+### CSRF
+
+Set `CSRF_SECRET` to a long, random value in production. If it is omitted, the backend falls back to `XAI_API_KEY` and then a development-only default so local setup remains simple.
+
 ### CORS
 
 Configure allowed origins:
@@ -202,6 +225,7 @@ The server provides comprehensive error handling with appropriate HTTP status co
 
 - `400` - Validation errors
 - `401` - Invalid API key  
+- `403` - Missing or invalid CSRF token
 - `429` - Rate limit exceeded
 - `500` - Internal server errors
 - `503` - Service unavailable

--- a/backend/__tests__/grokImageService.test.js
+++ b/backend/__tests__/grokImageService.test.js
@@ -2,6 +2,7 @@
  * Unit tests for GrokImageService
  */
 
+import { jest, describe, beforeEach, it, expect } from '@jest/globals';
 import GrokImageService from '../services/grokImageService.js';
 import axios from 'axios';
 

--- a/backend/__tests__/server.test.js
+++ b/backend/__tests__/server.test.js
@@ -2,6 +2,7 @@
  * Integration tests for Grok Image Proxy Backend
  */
 
+import { jest, describe, beforeEach, it, expect } from '@jest/globals';
 import request from 'supertest';
 
 // Mock the GrokImageService before importing the server
@@ -30,6 +31,28 @@ describe('Apophenia Backend API', () => {
     jest.clearAllMocks();
   });
 
+  async function getCsrfToken() {
+    const response = await request(app)
+      .get('/api/csrf-token')
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      csrfToken: expect.any(String),
+      headerName: 'x-csrf-token',
+      expiresInSeconds: expect.any(Number)
+    });
+
+    return response.body.csrfToken;
+  }
+
+  async function postGenerateImage(body) {
+    const csrfToken = await getCsrfToken();
+    return request(app)
+      .post('/api/generateImage')
+      .set('x-csrf-token', csrfToken)
+      .send(body);
+  }
+
   describe('GET /health', () => {
     it('should return health status', async () => {
       const response = await request(app)
@@ -44,6 +67,26 @@ describe('Apophenia Backend API', () => {
         services: {
           grok: expect.any(Boolean)
         }
+      });
+    });
+  });
+
+  describe('GET /api/csrf-token', () => {
+    it('should issue CSRF tokens for state-changing API calls', async () => {
+      await getCsrfToken();
+    });
+  });
+
+  describe('CSRF protection', () => {
+    it('should reject state-changing API calls without a valid CSRF token', async () => {
+      const response = await request(app)
+        .post('/api/generateImage')
+        .send({ prompt: 'A beautiful cosmic nebula with stars' })
+        .expect(403);
+
+      expect(response.body).toMatchObject({
+        error: 'Forbidden',
+        message: expect.stringContaining('CSRF token')
       });
     });
   });
@@ -70,9 +113,7 @@ describe('Apophenia Backend API', () => {
 
     describe('Success scenarios', () => {
       it('should generate images successfully with valid request', async () => {
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send(validRequestBody)
+        const response = await postGenerateImage(validRequestBody)
           .expect(200);
 
         expect(response.body).toMatchObject({
@@ -116,9 +157,7 @@ describe('Apophenia Backend API', () => {
         
         mockGrokService.generateImages.mockResolvedValue(base64Response);
 
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send(base64Request)
+        const response = await postGenerateImage(base64Request)
           .expect(200);
 
         expect(response.body.success).toBe(true);
@@ -133,9 +172,7 @@ describe('Apophenia Backend API', () => {
           prompt: 'A simple test image'
         };
 
-        await request(app)
-          .post('/api/generateImage')
-          .send(minimalRequest)
+        await postGenerateImage(minimalRequest)
           .expect(200);
 
         expect(mockGrokService.generateImages).toHaveBeenCalledWith(
@@ -148,9 +185,7 @@ describe('Apophenia Backend API', () => {
 
     describe('Validation errors', () => {
       it('should reject requests without prompt', async () => {
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send({
+        const response = await postGenerateImage({
             imageCount: 2
           })
           .expect(400);
@@ -168,9 +203,7 @@ describe('Apophenia Backend API', () => {
       });
 
       it('should reject prompts that are too short', async () => {
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send({
+        const response = await postGenerateImage({
             prompt: 'short'
           })
           .expect(400);
@@ -184,9 +217,7 @@ describe('Apophenia Backend API', () => {
       it('should reject prompts that are too long', async () => {
         const longPrompt = 'A'.repeat(1001);
         
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send({
+        const response = await postGenerateImage({
             prompt: longPrompt
           })
           .expect(400);
@@ -198,9 +229,7 @@ describe('Apophenia Backend API', () => {
       });
 
       it('should reject invalid imageCount values', async () => {
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send({
+        const response = await postGenerateImage({
             prompt: 'A valid prompt for testing',
             imageCount: 15
           })
@@ -213,9 +242,7 @@ describe('Apophenia Backend API', () => {
       });
 
       it('should reject invalid responseFormat values', async () => {
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send({
+        const response = await postGenerateImage({
             prompt: 'A valid prompt for testing',
             responseFormat: 'invalid'
           })
@@ -234,9 +261,7 @@ describe('Apophenia Backend API', () => {
           new Error('XAI_API_KEY not configured')
         );
 
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send(validRequestBody)
+        const response = await postGenerateImage(validRequestBody)
           .expect(500);
 
         expect(response.body).toMatchObject({
@@ -249,9 +274,7 @@ describe('Apophenia Backend API', () => {
           new Error('Request timeout')
         );
 
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send(validRequestBody)
+        const response = await postGenerateImage(validRequestBody)
           .expect(500);
 
         expect(response.body.error).toBeDefined();
@@ -262,9 +285,7 @@ describe('Apophenia Backend API', () => {
           new Error('Rate limit exceeded for Grok API')
         );
 
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send(validRequestBody)
+        const response = await postGenerateImage(validRequestBody)
           .expect(500);
 
         expect(response.body.error).toBeDefined();
@@ -275,9 +296,7 @@ describe('Apophenia Backend API', () => {
       it('should apply rate limits to API endpoints', async () => {
         // This is a basic test - in a real scenario you'd need to make multiple requests
         // to trigger rate limiting, but that would make the test slow and flaky
-        const response = await request(app)
-          .post('/api/generateImage')
-          .send(validRequestBody)
+        const response = await postGenerateImage(validRequestBody)
           .expect(200);
 
         expect(response.headers).toHaveProperty('ratelimit-limit');
@@ -298,6 +317,7 @@ describe('Apophenia Backend API', () => {
         message: expect.stringContaining('not found'),
         availableEndpoints: expect.arrayContaining([
           'GET /health',
+          'GET /api/csrf-token',
           'POST /api/generateImage'
         ])
       });

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,11 +6,17 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "jest --watch",
     "lint": "eslint . --ext .js,.ts"
   },
-  "keywords": ["express", "grok", "image-generation", "proxy", "api"],
+  "keywords": [
+    "express",
+    "grok",
+    "image-generation",
+    "proxy",
+    "api"
+  ],
   "author": "Phazzie",
   "license": "ISC",
   "dependencies": {
@@ -33,6 +39,10 @@
     "testEnvironment": "node",
     "collectCoverage": true,
     "coverageDirectory": "coverage",
-    "testMatch": ["**/__tests__/**/*.test.js", "**/*.test.js"]
-  }
+    "testMatch": [
+      "**/__tests__/**/*.test.js",
+      "**/*.test.js"
+    ]
+  },
+  "type": "module"
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,6 +10,7 @@ import express from 'express';
 import cors from 'cors';
 import rateLimit from 'express-rate-limit';
 import Joi from 'joi';
+import crypto from 'node:crypto';
 
 // Import services
 import GrokImageService from './services/grokImageService.js';
@@ -21,6 +22,71 @@ const logger = createLogger();
 
 // Initialize services - allow injection for testing
 let grokImageService = new GrokImageService(process.env.XAI_API_KEY, logger);
+
+
+const CSRF_HEADER_NAME = 'x-csrf-token';
+const CSRF_TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+const CSRF_SECRET = process.env.CSRF_SECRET || process.env.XAI_API_KEY || 'development-csrf-secret';
+
+function signCsrfPayload(payload) {
+  return crypto
+    .createHmac('sha256', CSRF_SECRET)
+    .update(payload)
+    .digest('base64url');
+}
+
+function createCsrfToken() {
+  const timestamp = Date.now().toString();
+  const nonce = crypto.randomBytes(16).toString('base64url');
+  const payload = `${timestamp}.${nonce}`;
+  return `${payload}.${signCsrfPayload(payload)}`;
+}
+
+function validateCsrfToken(token) {
+  if (typeof token !== 'string') {
+    return false;
+  }
+
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    return false;
+  }
+
+  const [timestamp, nonce, signature] = parts;
+  const issuedAt = Number(timestamp);
+  if (!Number.isFinite(issuedAt) || Date.now() - issuedAt > CSRF_TOKEN_TTL_MS) {
+    return false;
+  }
+
+  const payload = `${timestamp}.${nonce}`;
+  const expectedSignature = signCsrfPayload(payload);
+  const provided = Buffer.from(signature);
+  const expected = Buffer.from(expectedSignature);
+
+  return provided.length === expected.length && crypto.timingSafeEqual(provided, expected);
+}
+
+function csrfProtection(req, res, next) {
+  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method)) {
+    return next();
+  }
+
+  const token = req.get(CSRF_HEADER_NAME);
+  if (!validateCsrfToken(token)) {
+    logger.warn('CSRF validation failed', {
+      method: req.method,
+      path: req.path,
+      ip: req.ip
+    });
+
+    return res.status(403).json({
+      error: 'Forbidden',
+      message: 'Valid CSRF token required for state-changing API requests'
+    });
+  }
+
+  return next();
+}
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -64,13 +130,23 @@ const rateLimiter = rateLimit({
 app.use(cors({
   origin: process.env.CORS_ORIGIN || '*',
   methods: ['GET', 'POST'],
-  allowedHeaders: ['Content-Type', 'Authorization']
+  allowedHeaders: ['Content-Type', 'Authorization', CSRF_HEADER_NAME]
 }));
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
 // Apply rate limiting to API routes
 app.use('/api', rateLimiter);
+
+app.get('/api/csrf-token', (_req, res) => {
+  res.json({
+    csrfToken: createCsrfToken(),
+    headerName: CSRF_HEADER_NAME,
+    expiresInSeconds: CSRF_TOKEN_TTL_MS / 1000
+  });
+});
+
+app.use('/api', csrfProtection);
 
 // Request logging middleware
 app.use((req, res, next) => {
@@ -216,6 +292,7 @@ app.use((req, res) => {
     message: `Endpoint ${req.method} ${req.url} not found`,
     availableEndpoints: [
       'GET /health',
+      'GET /api/csrf-token',
       'POST /api/generateImage'
     ]
   });

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "server:dev": "npx nodemon server.js",
     "fullstack:dev": "npx concurrently \"npm run server:dev\" \"npm run dev\"",
     "build:all": "npm run build && echo 'Frontend built. Deploy server.js separately for backend.'",
-    "start:prod": "node server.js"
+    "start:prod": "node server.js",
+    "check:features": "node scripts/check-features.js"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.16.1",

--- a/scripts/check-features.js
+++ b/scripts/check-features.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Feature coverage checker.
+ *
+ * Scans repository source files for feature keywords and verifies matching tests exist.
+ * All recursive filesystem access is constrained to REPO_ROOT to avoid path traversal
+ * findings from automated code review tools.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(__filename), '..');
+const SOURCE_DIRS = ['src', 'backend'].map((dir) => path.join(REPO_ROOT, dir));
+const TEST_EXTENSIONS = ['.test.js', '.test.jsx', '.test.ts', '.test.tsx', '.spec.js', '.spec.jsx', '.spec.ts', '.spec.tsx'];
+const SOURCE_EXTENSIONS = ['.js', '.jsx', '.ts', '.tsx'];
+const IGNORED_DIRS = new Set(['.git', 'node_modules', 'dist', 'coverage', 'build', '.next', '.vite']);
+const FEATURE_TERMS = [
+  'temporal revision',
+  'quantum narrative',
+  'reality corruption',
+  'adaptive horror',
+  'grok image',
+  'csrf'
+];
+
+function safeResolve(...segments) {
+  const resolved = path.resolve(...segments);
+  const relative = path.relative(REPO_ROOT, resolved);
+
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to access path outside repository root: ${resolved}`);
+  }
+
+  return resolved;
+}
+
+function safeJoin(baseDir, entryName) {
+  return safeResolve(baseDir, entryName);
+}
+
+function readDirectorySafe(dir) {
+  const safeDir = safeResolve(dir);
+  return fs.readdirSync(safeDir, { withFileTypes: true });
+}
+
+function readFileSafe(filePath) {
+  return fs.readFileSync(safeResolve(filePath), 'utf8');
+}
+
+function collectFiles(startDir, predicate, files = []) {
+  if (!fs.existsSync(startDir)) {
+    return files;
+  }
+
+  for (const entry of readDirectorySafe(startDir)) {
+    if (entry.name.startsWith('.') || IGNORED_DIRS.has(entry.name)) {
+      continue;
+    }
+
+    const entryPath = safeJoin(startDir, entry.name);
+
+    if (entry.isDirectory()) {
+      collectFiles(entryPath, predicate, files);
+    } else if (entry.isFile() && predicate(entryPath)) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function hasSupportedSourceExtension(filePath) {
+  return SOURCE_EXTENSIONS.includes(path.extname(filePath));
+}
+
+function hasTestExtension(filePath) {
+  return TEST_EXTENSIONS.some((extension) => filePath.endsWith(extension));
+}
+
+function collectFeatureHits(sourceFiles) {
+  return sourceFiles.flatMap((filePath) => {
+    const content = readFileSafe(filePath).toLowerCase();
+    return FEATURE_TERMS
+      .filter((term) => content.includes(term))
+      .map((term) => ({ term, filePath: path.relative(REPO_ROOT, filePath) }));
+  });
+}
+
+function main() {
+  const sourceFiles = SOURCE_DIRS.flatMap((sourceDir) =>
+    collectFiles(sourceDir, (filePath) => hasSupportedSourceExtension(filePath) && !hasTestExtension(filePath))
+  );
+  const testFiles = SOURCE_DIRS.flatMap((sourceDir) => collectFiles(sourceDir, hasTestExtension));
+  const featureHits = collectFeatureHits(sourceFiles);
+
+  const report = {
+    repositoryRoot: REPO_ROOT,
+    sourceFilesScanned: sourceFiles.length,
+    testFilesFound: testFiles.map((filePath) => path.relative(REPO_ROOT, filePath)),
+    featureHits
+  };
+
+  console.log(JSON.stringify(report, null, 2));
+
+  if (featureHits.length > 0 && testFiles.length === 0) {
+    console.error('Feature-like source code was found, but no test files were discovered.');
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
### Motivation
- Checklist: [x] add CSRF protection to backend, [x] document CSRF flow, [x] update backend tests to use issued CSRF tokens, [x] harden feature-scanner to prevent path traversal and expose it via `npm run check:features`, [x] adjust backend Jest/ESM test setup, [ ] fix `AIPROMPTS.md` markdown lint (file not present here), [ ] configure external Vercel secret (out-of-repo).
- Purpose: address security and review comments reported across open PRs by applying server-side CSRF defenses, improving test coverage for the Grok image endpoint, and fixing a filesystem-traversal concern in the feature-checker.
- Scope: changes touch the backend server, backend tests, backend docs, repo `package.json`, and add a safe feature-checker script under `scripts/` to be used in CI or locally.

### Description
- Backend CSRF protections: added signed CSRF token generation/validation logic and a `GET /api/csrf-token` endpoint, enforced token checks for state-changing HTTP methods, and allowed the `x-csrf-token` header in CORS; changes are in `backend/server.js`.
- Tests and test config: updated integration/unit tests to obtain and send CSRF tokens for state-changing calls and to assert that missing tokens are rejected, and adjusted backend package Jest settings to support ESM imports and `@jest/globals`; changes are in `backend/__tests__/server.test.js`, `backend/__tests__/grokImageService.test.js`, and `backend/package.json`.
- Feature scanner hardening: added `scripts/check-features.js` which constrains all filesystem traversal to the repository root with `safeResolve`/`safeJoin`/safe read helpers and reports feature hits; the checker is exposed via `npm run check:features` in the repo `package.json`.
- Documentation: documented the CSRF flow, `CSRF_SECRET` usage, required `x-csrf-token` header, and example `curl` usage in `backend/README.md`.

### Testing
- Syntax / static checks: ran `node --check` on `backend/server.js` and backend tests and they passed (no syntax errors). (✅)
- Feature-checker: ran `npm run check:features` which executed `scripts/check-features.js` and produced a feature report (✅).
- Full test runs: attempted root test run `npm test -- --run` but `npx` attempted to fetch `vitest` and the environment blocked npm registry access (HTTP 403), so root test run could not complete (⚠️).
- Backend tests: updated backend `package.json` to run Jest under ESM (`NODE_OPTIONS=--experimental-vm-modules jest`) and modified tests to import `@jest/globals`, but a full `cd backend && npm test` could not be completed here because `supertest`/`axios` dependencies were not available to the environment and network install is blocked (tests are ready to run in a normal environment once dependencies are installed) (⚠️).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a064d62eb2483209b3377050548bf35)

## Summary by Sourcery

Add CSRF protection to the backend API, harden the feature-scanning script, and update tests and configuration to support the new security and testing flows.

New Features:
- Introduce a signed CSRF token mechanism with a dedicated endpoint and enforcement middleware for state-changing API routes.
- Add a repository feature-scanner script and expose it via an npm script for local and CI usage.

Enhancements:
- Expand backend documentation to cover CSRF usage, configuration, and example requests.
- Adjust backend Jest/ESM configuration and scripts to support running tests under Node's experimental VM modules.

Tests:
- Update backend API tests to obtain and pass CSRF tokens and verify that missing tokens are rejected.